### PR TITLE
v0.18.0 + v0.19.0: one container with Postgres inside; releases built natively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Weekly, grouped. The CI run is ~18 minutes and the test tier is serial on purpose, so one grouped pull
+# request per ecosystem per week is the right cadence -- thirty single-package PRs would each cost that.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /bff
+    schedule: { interval: weekly, day: monday }
+    groups:
+      bff-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 3
+  - package-ecosystem: npm
+    directory: /web
+    schedule: { interval: weekly, day: monday }
+    groups:
+      web-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly, day: monday }
+  # The base images in the three Dockerfiles (node:22-alpine, nginx:1.27-alpine).
+  - package-ecosystem: docker
+    directory: /
+    schedule: { interval: weekly, day: monday }
+  - package-ecosystem: docker
+    directory: /bff
+    schedule: { interval: weekly, day: monday }
+  - package-ecosystem: docker
+    directory: /web
+    schedule: { interval: weekly, day: monday }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
   e2e:
     name: Browser end-to-end
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -78,9 +78,15 @@ jobs:
       - name: Every language renders, and Arabic mirrors
         working-directory: ./web
         run: npm run test:i18n
+      # The same browser suite against the one-container layout: no Postgres container, DATABASE_URL unset,
+      # the image running its own database. A second STEP rather than a matrix, on purpose: the job's name
+      # is one of the five required status checks, and a matrix renames it.
+      - name: Bring it up again with the embedded database, and drive it
+        working-directory: ./web
+        run: E2E_EMBEDDED=1 E2E_NET=uchiyomi-e2e-embedded E2E_PORT=18141 E2E_SUBNET=10.222.1.0/24 npm run test:e2e
       - name: Tear it down
         if: always()
-        run: docker rm -f uchiyomi-e2e uchiyomi-e2e-db || true
+        run: docker rm -f uchiyomi-e2e uchiyomi-e2e-db uchiyomi-e2e-embedded || true
       - name: Keep the screenshots when it fails
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+# Static analysis of the TypeScript, on every push to main and pull request, and weekly so a newly published
+# query still runs against an unchanged tree. Not a required status check: findings land in the Security tab.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,24 @@
 name: Release
 
 # Publishes multi-arch Docker images to GHCR when you push a version tag (e.g. `git tag v0.1.0 && git push --tags`).
-# Uses the built-in GITHUB_TOKEN (no extra secrets). The published images are what make the CasaOS/Unraid/Umbrel
-# one-click manifests installable.
+# Uses the built-in GITHUB_TOKEN plus the id-token for attestations. The published images are what make the
+# CasaOS/Unraid/Umbrel one-click manifests installable.
 #
-# Two things here are scars rather than style.
+# Three things here are scars rather than style.
+#
+# Each architecture is built on a runner OF that architecture, and the two results are merged into one
+# index afterwards. Until v0.19.0 arm64 was cross-built under QEMU on an amd64 runner, and that broke four of
+# five releases: the native-module builds (sharp, mupdf, argon2) either hung until the timeout or died with
+# SIGILL, and `gh run rerun --failed` was the standing workaround. Native runners remove the cause; the
+# merge step is what keeps "one tag, both architectures" true.
 #
 # `timeout-minutes` exists because v0.7.0's web leg stalled inside QEMU and sat there for the full six-hour
-# GitHub maximum before anyone found out. A healthy build of either image is two to eight minutes, so 40 is
-# generous and still fails the same day.
+# GitHub maximum before anyone found out. A healthy build of either image is two to eight minutes.
 #
-# `:latest` is moved by a separate job that runs only after BOTH images have published. The legs are
-# independent, so before this an image that built in two minutes would move its own `:latest` while the other
-# leg was still going, and if that one then failed, `docker compose pull` handed people a bff from one release
-# and a web from another. v0.5.1 half-published this way and v0.7.0 did it again.
+# `:latest` is moved by a separate job that runs only after EVERY image has published under the version tag.
+# The legs are independent, so before this an image that built in two minutes would move its own `:latest`
+# while another was still going, and if that one then failed, `docker compose pull` handed people a bff from
+# one release and a web from another. v0.5.1 half-published this way and v0.7.0 did it again.
 
 on:
   push:
@@ -22,25 +27,36 @@ on:
 permissions:
   contents: read
   packages: write
+  # for the build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  IMAGES: ghcr.io/angelosha/uchiyomi-bff ghcr.io/angelosha/uchiyomi-web ghcr.io/angelosha/uchiyomi
 
 jobs:
-  images:
-    runs-on: ubuntu-latest
+  build:
+    name: build ${{ matrix.service }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
     strategy:
       # Publish whichever image can be published: a failure in one leg should not cancel a working build of
-      # the other. `latest` is gated on both succeeding, so a half-publish cannot reach anyone via :latest.
+      # the other. `latest` is gated on all of them succeeding, so a half-publish cannot reach anyone via :latest.
       fail-fast: false
       matrix:
+        service: [bff, web, aio]
+        arch: [amd64, arm64]
         include:
           - { service: bff, image: ghcr.io/angelosha/uchiyomi-bff, context: ./bff,  file: ./bff/Dockerfile }
           - { service: web, image: ghcr.io/angelosha/uchiyomi-web, context: ./web,  file: ./web/Dockerfile }
           # The single-container build: the same API serving the web app itself. Its context is the repo
           # root because it builds both halves.
           - { service: aio, image: ghcr.io/angelosha/uchiyomi,     context: .,      file: ./Dockerfile.aio }
+          # Native runners, no emulation: ubuntu-24.04-arm is a real arm64 machine (free for public repos).
+          - { arch: amd64, runner: ubuntu-latest }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -48,15 +64,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push ${{ matrix.service }}
+      - name: Build and push ${{ matrix.service }} for ${{ matrix.arch }}, by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          # version tag only. See the note at the top about why `latest` is not set here.
-          tags: ${{ matrix.image }}:${{ github.ref_name }}
+          platforms: linux/${{ matrix.arch }}
+          # No tag here: each architecture is pushed by digest and the merge job below writes the tag over
+          # both. A per-arch tag would be a moment where the tag pointed at one architecture only.
+          outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
           # OCI labels: what the GHCR package page shows, and how tooling traces an image back to its
           # source and release. Absent until v0.9.2, so package pages had no description or licence.
           labels: |
@@ -67,11 +86,71 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=MPL-2.0
+      - name: Record the digest
+        run: |
+          mkdir -p digests
+          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.service }}-${{ matrix.arch }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.service }}-${{ matrix.arch }}
+          path: digests/*
+          retention-days: 1
 
-  # Only once BOTH images exist at this version does `latest` move. Re-tagging a manifest copies no layers,
+  # One index per image, written over both architectures' digests, and only then the version tag exists.
+  merge:
+    name: merge ${{ matrix.service }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { service: bff, image: ghcr.io/angelosha/uchiyomi-bff }
+          - { service: web, image: ghcr.io/angelosha/uchiyomi-web }
+          - { service: aio, image: ghcr.io/angelosha/uchiyomi }
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.service }}-*
+          path: digests
+          merge-multiple: true
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Write ${{ matrix.image }}:${{ github.ref_name }} over both architectures
+        id: index
+        run: |
+          set -euo pipefail
+          ls digests
+          refs=""
+          for f in digests/${{ matrix.service }}-*; do refs="$refs ${{ matrix.image }}@$(cat "$f")"; done
+          docker buildx imagetools create -t "${{ matrix.image }}:${{ github.ref_name }}" $refs
+          docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}"
+          # Both architectures must be in the index, or the tag is a half-publish with a new spelling.
+          for arch in amd64 arm64; do
+            docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}" | grep -q "linux/$arch" \
+              || { echo "::error::${{ matrix.image }}:${{ github.ref_name }} has no linux/$arch"; exit 1; }
+          done
+          digest=$(docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}" | awk '/^Digest:/{print $2; exit}')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "::notice title=${{ matrix.image }}:${{ github.ref_name }}::$digest   (this is the digest an Umbrel manifest pins)"
+      # A signed statement, verifiable with `gh attestation verify oci://<image>:<tag> --owner AngeloSha`,
+      # that this index was built by this workflow from this commit.
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.index.outputs.digest }}
+          push-to-registry: true
+
+  # Only once EVERY image exists at this version does `latest` move. Re-tagging a manifest copies no layers,
   # so this is a few seconds and cannot itself half-apply in a way that matters.
   latest:
-    needs: images
+    needs: merge
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -84,16 +163,16 @@ jobs:
       - name: Point latest at ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          for img in ghcr.io/angelosha/uchiyomi-bff ghcr.io/angelosha/uchiyomi-web ghcr.io/angelosha/uchiyomi; do
+          for img in $IMAGES; do
             echo "retagging $img:${GITHUB_REF_NAME} -> :latest"
             docker buildx imagetools create -t "$img:latest" "$img:${GITHUB_REF_NAME}"
           done
-      - name: Verify both images resolve to the same digest under both tags
+      - name: Verify every image resolves to the same digest under both tags
         run: |
           set -euo pipefail
-          for img in ghcr.io/angelosha/uchiyomi-bff ghcr.io/angelosha/uchiyomi-web ghcr.io/angelosha/uchiyomi; do
-            v=$(docker buildx imagetools inspect "$img:${GITHUB_REF_NAME}" --format '{{.Manifest.Digest}}')
-            l=$(docker buildx imagetools inspect "$img:latest" --format '{{.Manifest.Digest}}')
+          for img in $IMAGES; do
+            v=$(docker buildx imagetools inspect "$img:${GITHUB_REF_NAME}" | awk '/^Digest:/{print $2; exit}')
+            l=$(docker buildx imagetools inspect "$img:latest" | awk '/^Digest:/{print $2; exit}')
             echo "$img  version=$v  latest=$l"
-            [ "$v" = "$l" ] || { echo "::error::$img latest does not match ${GITHUB_REF_NAME}"; exit 1; }
+            [ -n "$v" ] && [ "$v" = "$l" ] || { echo "::error::$img latest does not match ${GITHUB_REF_NAME}"; exit 1; }
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,13 +130,18 @@ jobs:
           refs=""
           for f in digests/${{ matrix.service }}-*; do refs="$refs ${{ matrix.image }}@$(cat "$f")"; done
           docker buildx imagetools create -t "${{ matrix.image }}:${{ github.ref_name }}" $refs
-          docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}"
+          # Inspect ONCE into a variable and read from that. Piping the inspect into `grep -q` or an awk
+          # that exits early closes the pipe under it; buildx then dies of SIGPIPE, and with pipefail that
+          # is the step's exit status (255) -- which is exactly how the first run of this pipeline failed
+          # all three merges after every build had succeeded.
+          out=$(docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}")
+          printf '%s\n' "$out"
           # Both architectures must be in the index, or the tag is a half-publish with a new spelling.
           for arch in amd64 arm64; do
-            docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}" | grep -q "linux/$arch" \
+            grep -q "linux/$arch" <<<"$out" \
               || { echo "::error::${{ matrix.image }}:${{ github.ref_name }} has no linux/$arch"; exit 1; }
           done
-          digest=$(docker buildx imagetools inspect "${{ matrix.image }}:${{ github.ref_name }}" | awk '/^Digest:/{print $2; exit}')
+          digest=$(awk '/^Digest:/ && !d {print $2; d=1}' <<<"$out")
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "::notice title=${{ matrix.image }}:${{ github.ref_name }}::$digest   (this is the digest an Umbrel manifest pins)"
       # A signed statement, verifiable with `gh attestation verify oci://<image>:<tag> --owner AngeloSha`,
@@ -170,9 +175,11 @@ jobs:
       - name: Verify every image resolves to the same digest under both tags
         run: |
           set -euo pipefail
+          # No early-exiting awk on a pipe from buildx: see the merge job for why.
+          digest_of() { local out; out=$(docker buildx imagetools inspect "$1"); awk '/^Digest:/ && !d {print $2; d=1}' <<<"$out"; }
           for img in $IMAGES; do
-            v=$(docker buildx imagetools inspect "$img:${GITHUB_REF_NAME}" | awk '/^Digest:/{print $2; exit}')
-            l=$(docker buildx imagetools inspect "$img:latest" | awk '/^Digest:/{print $2; exit}')
+            v=$(digest_of "$img:${GITHUB_REF_NAME}")
+            l=$(digest_of "$img:latest")
             echo "$img  version=$v  latest=$l"
             [ -n "$v" ] && [ "$v" = "$l" ] || { echo "::error::$img latest does not match ${GITHUB_REF_NAME}"; exit 1; }
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.18.0 — 2026-09-04
+
+### One container, database included
+
+Leave `DATABASE_URL` unset and the container runs its own Postgres: initialised on first start in the
+`uchiyomi_data` volume, listening on a unix socket only -- nothing outside the container can reach it and
+there is no password to manage -- and started before the app so the app never races it. That one variable
+is the whole switch. Set it, as every install before this release has, and none of it runs; the container
+behaves exactly as it did.
+
+`deploy/docker-compose.yml`, the file the install instructions curl, is now that one container plus the
+optional solver and extension engine. The layout with a Postgres container beside the app is still shipped
+as `deploy/docker-compose.external-db.yml` and is still supported; `docs/MIGRATING.md` has the move in both
+directions, which is a dump and a restore over the socket. App stores expect a one-container app, and this
+is what makes the Unraid and Umbrel manifests in the next release possible at all.
+
+The container is now a supervisor for exactly two processes and knows which one is the database. On
+`docker stop` the app finishes what it is writing and then Postgres stops cleanly (the compose file gives it
+a 40 s grace period, because Docker's default ten would kill a checkpoint). If Postgres dies underneath the
+app, the app is stopped so the container exits and `restart: unless-stopped` brings both back in order,
+which is the opposite of what an init system's restart-the-service semantics would do to a database. A data
+directory from a different Postgres major is refused up front, with the upgrade path named, rather than
+crash-looping on an error nobody should have to decode. Docker's own healthcheck asks Postgres too when it
+is inside, and the admin overview says which layout this is in one word.
+
+The browser end-to-end suite now drives both layouts on every commit, and the entrypoint itself is driven
+as a script with fake Postgres binaries that record their arguments. That harness caught two mistakes before
+they shipped: the socket directory was never created when the container runs as a non-root `user:`, and the
+app was launched through a shell function in the background -- which puts it in a subshell, so the signal
+sent on `docker stop` would have stopped the subshell and left the app running with its database gone.
+
 ## v0.17.0 — 2026-09-04
 
 ### The API has a reference now, and it cannot fall behind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.19.0 — 2026-09-04
+
+### Releases that build on the machine they run on
+
+Every arm64 image used to be cross-built under emulation on an amd64 machine, and that broke four of the
+last five releases the same way: the native-module builds hung until the timeout or died on an illegal
+instruction, and re-running the failed half was the standing fix. Each architecture is now built on a
+machine of that architecture and the two are merged into one image afterwards. The version tag exists only
+once both halves do, and `latest` moves only once every image has both, so a half-built release cannot
+reach anyone through either.
+
+Every published image now carries a signed statement of which workflow built it from which commit, and a
+software bill of materials. `gh attestation verify oci://ghcr.io/angelosha/uchiyomi:v0.19.0 --owner AngeloSha`
+checks it.
+
+### Watched dependencies, scanned code
+
+Dependabot watches the two npm trees, the workflow actions and the base images of all three Dockerfiles,
+weekly and grouped, so the eighteen-minute test run happens once per ecosystem per week rather than thirty
+times. CodeQL scans the TypeScript on every push and weekly; findings land in the repository's Security tab.
+
+### Unraid and Umbrel
+
+An Unraid Community Applications template (`deploy/unraid/uchiyomi.xml`) and an Umbrel app
+(`deploy/umbrel/uchiyomi/`), both the one-container layout with the database inside, which is what both
+stores expect and what v0.18.0 made possible. Honesty note: the Umbrel manifest is written to Umbrel's
+published format and tested for shape, but has not yet been run on umbrelOS itself; its store submission is
+a pull request to Umbrel's app repository, and it pins the image by digest, which is filled in once this
+release exists.
+
 ## v0.18.0 — 2026-09-04
 
 ### One container, database included

--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -6,8 +6,12 @@
 # files is unusual here, and it is what produced the redirect that dropped the port on every deep link.
 #
 # What this removes: one image to build, publish, pull and update; one hop on every request; and one config
-# file whose behaviour had to be reproduced anyway. What it keeps: Postgres stays its own container, because
-# a database is a database.
+# file whose behaviour had to be reproduced anyway.
+#
+# Postgres can be its own container, as it always was, or live inside this one: leave DATABASE_URL unset and
+# the entrypoint runs Postgres on a unix socket in /data/pg (see docker-entrypoint.sh). That is what makes
+# a one-container install possible, which is what every app store expects. Set DATABASE_URL and none of it
+# runs; nothing changes for an existing install.
 #
 #   docker build -f Dockerfile.aio -t uchiyomi:aio .
 
@@ -43,11 +47,19 @@ ENV NODE_ENV=production
 # disk is a 20-byte empty archive in a directory that looks like a backup. aioParity.test.ts now holds the
 # line, because "the split image did this and the single one quietly stopped" is the whole class of bug that
 # file exists for.
-RUN apk add --no-cache su-exec tini postgresql16-client \
+#
+# postgresql16 (the server, 14 MiB) is what embedded mode runs; the same major as the client on purpose, and
+# aioParity.test.ts checks they agree, because pg_dump from a newer major writes archives an older server
+# cannot restore. nss_wrapper (23 KB) is for the uid Postgres runs as: initdb refuses a uid with no passwd
+# entry, and a container started with `user:` has exactly that; the official postgres image uses the same
+# library for the same reason. (With PUID the entrypoint adds a real entry instead and never needs it.) /data and /run/postgresql exist and are owned up front for the same reason the other
+# volumes are: a named volume is seeded from the image directory, and a missing one becomes a root-owned
+# mountpoint the app cannot write.
+RUN apk add --no-cache su-exec tini postgresql16 postgresql16-client nss_wrapper \
  && addgroup -g 10002 -S yomi \
  && adduser -u 10002 -S -G yomi yomi \
- && mkdir -p /cache /backups /config /library-dl /library /sources \
- && chown -R yomi:yomi /cache /backups /config /library-dl /app
+ && mkdir -p /cache /backups /config /library-dl /library /sources /data /run/postgresql \
+ && chown -R yomi:yomi /cache /backups /config /library-dl /app /data /run/postgresql
 
 COPY bff/package.json bff/package-lock.json* ./
 RUN npm ci --omit=dev --no-audit --no-fund 2>/dev/null || npm install --omit=dev --no-audit --no-fund \
@@ -69,7 +81,10 @@ EXPOSE 3000
 # /livez, not /healthz. /healthz runs SELECT 1, which is the right answer for "should traffic be sent here"
 # and the wrong one for a container healthcheck: it makes one Postgres blip mark the whole app unhealthy,
 # where the split layout's nginx stayed up and kept serving the shell so the app could render an error.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/livez >/dev/null 2>&1 || exit 1
+# In embedded mode the database is part of "alive": the entrypoint leaves a marker next to the socket, and
+# the check asks Postgres too. With an external database the marker does not exist and this is /livez alone.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD sh -c 'wget -qO- http://127.0.0.1:3000/livez >/dev/null 2>&1 || exit 1; \
+    for d in /run/postgresql /tmp/pgsock; do [ -f "$d/.embedded" ] && { pg_isready -q -h "$d" -U yomi || exit 1; }; done; exit 0'
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ as a custom app and it appears with an icon like any store app. That manifest le
 engine, so Mihon/Tachiyomi extensions are off there; add `uchiyomi-suwayomi` from
 [`deploy/docker-compose.yml`](deploy/docker-compose.yml) and set `SUWAYOMI_URL` if you want them.
 
+**On Unraid?** Add `https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/unraid/uchiyomi.xml`
+under *Docker → Add Container → Template repositories* (or install from Community Applications once it is
+listed). One container, database included; set PUID/PGID to the owner of your library for renames.
+
+**On Umbrel?** The app manifest lives at [`deploy/umbrel/uchiyomi`](deploy/umbrel/uchiyomi) and is
+submitted to the Umbrel app store from there. It runs as Umbrel's own user with the database inside the
+container; nothing to configure.
+
 What you end up running:
 
 | Container | Role |

--- a/README.md
+++ b/README.md
@@ -238,9 +238,20 @@ docker compose up -d
 Then open **http://localhost:8080** and **create your admin account right in the browser**. There are no
 secrets to generate and no config file to edit.
 
-That is **Uchiyomi in one container**, plus Postgres. Two more are optional: a Cloudflare solver, which the
+That is **Uchiyomi in one container, database included**: Postgres runs inside it, on a unix socket, in a
+volume of its own, and there is nothing to configure. Two more are optional: a Cloudflare solver, which the
 fetching half needs for most aggregators, and the extension engine, which is a JVM and costs about 800 MB.
-Leave the extension engine out and it is three containers; only the first two are Uchiyomi itself.
+Leave the extension engine out and it is two containers; only the first is Uchiyomi itself.
+
+<details>
+<summary>Prefer to run Postgres yourself?</summary>
+
+Set `DATABASE_URL` and the same image talks to your database instead of starting its own; that one variable
+is the whole switch. [`deploy/docker-compose.external-db.yml`](deploy/docker-compose.external-db.yml) is
+that layout ready to use, with a Postgres container beside the app -- it is what the install instructions
+used before v0.18.0, and an existing install keeps working on it unchanged. Moving between the two is a
+dump and a restore, written down in both directions in **[docs/MIGRATING.md](docs/MIGRATING.md)**.
+</details>
 
 <details>
 <summary>Already running the older two-container layout?</summary>
@@ -254,9 +265,9 @@ It is deprecated because the single container measured better on the same host â
 the end-to-end tests only ever drive the single container, so it is the layout that is actually proven on
 every commit.
 
-Moving is a compose swap, not a data migration: both layouts use the **same named volumes** and the same
-Postgres image. Four commands, in **[docs/MIGRATING.md](docs/MIGRATING.md)**. The file itself is still there
-as [`deploy/docker-compose.split.yml`](deploy/docker-compose.split.yml).
+Moving to the external-database layout is a compose swap, not a data migration: both use the **same named
+volumes** and the same Postgres image. Four commands, in **[docs/MIGRATING.md](docs/MIGRATING.md)**. The
+file itself is still there as [`deploy/docker-compose.split.yml`](deploy/docker-compose.split.yml).
 </details>
 
 To read a library you already have, point `LIBRARY_PATH` at it. By default Uchiyomi runs as its own user and

--- a/bff/docker-entrypoint.sh
+++ b/bff/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Run as the uid that actually owns your library, then drop privileges.
+# Run as the uid that actually owns your library, then drop privileges -- and, when no database was given,
+# run one.
 #
 # Uchiyomi can rename and delete files in your library now, and a container running as uid 10002 cannot write
 # a library owned by you. The usual fix people are told is `chown -R 10002 /your/manga`, which takes ownership
@@ -11,56 +12,204 @@
 # never starts as root at all. That is not politeness: v0.5.1 was entirely a volume-ownership bug (a fresh
 # install could not write /config, so the JWT secret could not be saved and everyone was signed out on every
 # restart), and this script is now the thing standing between that failure and a repeat of it.
+#
+# EMBEDDED POSTGRES. With DATABASE_URL unset, this starts a Postgres of its own on a unix socket, in /data/pg,
+# and points the app at it; with DATABASE_URL set, nothing below the "embedded" line runs and the container
+# behaves exactly as it always has. That one variable is the whole switch, so an existing install with an
+# external database cannot drift into this path by accident.
+#
+# Why an entrypoint and not an init system: if Postgres dies the right outcome is for the CONTAINER to exit
+# and `restart: unless-stopped` to bring both halves back in order, which is the opposite of what an init
+# system's restart-the-service semantics would do to a database. tini stays PID 1; this script is the
+# supervisor for exactly two processes and knows which one is the database.
 set -eu
 
 APP_UID="${PUID:-10002}"
 APP_GID="${PGID:-10002}"
+PGDATA="${PGDATA:-/data/pg}"
+PGSOCK="${PGSOCK:-/run/postgresql}"
+EMBEDDED=0
+[ -z "${DATABASE_URL:-}" ] && EMBEDDED=1
 
-# Not root: someone set `user:` in compose, which bypasses this script's ability to adjust anything. Say so
-# plainly and carry on rather than failing, because it is a legitimate way to run the container.
-if [ "$(id -u)" != "0" ]; then
-  echo "[entrypoint] running as uid $(id -u); PUID/PGID ignored (the container was not started as root)"
-  exec "$@"
-fi
+ROOT=0
+[ "$(id -u)" = "0" ] && ROOT=1
 
-if [ "$APP_UID" = "0" ]; then
+if [ "$ROOT" = 1 ] && [ "$APP_UID" = "0" ]; then
   echo "[entrypoint] refusing to run the app as root. Set PUID/PGID to the owner of your library." >&2
   exit 1
 fi
 
-# Deliberately NO usermod/groupmod. The base image already ships a user at uid 1000 (node), so renumbering
-# the app user collides with it and the container crash-loops on "UID '1000' already exists" -- which is
-# exactly what happened the first time this ran against a real library owned by uid 1000.
-#
-# su-exec takes numeric ids, and nothing in the app resolves its own username, so the app user simply does
-# not need to own the number. Dropping this also drops the shadow dependency.
+# Run something as the app user. Root drops with su-exec; a container started with `user:` is already the
+# app user and just runs it. Postgres refuses to run as root, so the embedded database needs this too.
+as_app() {
+  if [ "$ROOT" = 1 ]; then su-exec "$APP_UID:$APP_GID" "$@"; else "$@"; fi
+}
 
-# Only the volumes the app owns. NEVER /library: that is the user's collection, and taking ownership of it is
-# the exact thing PUID exists to avoid.
-#
-# The recursion is conditional because /cache holds tens of thousands of files (61,336 / 11.3 GB on the
-# instance this was written against) and a blind `chown -R` would stat every one of them on every single
-# container start, to change nothing.
-for d in /config /library-dl /backups /cache; do
-  [ -d "$d" ] || continue
-  owner="$(stat -c '%u' "$d" 2>/dev/null || echo '')"
-  if [ "$owner" != "$APP_UID" ]; then
-    echo "[entrypoint] taking ownership of $d ($owner -> $APP_UID)"
-    chown -R "$APP_UID:$APP_GID" "$d" || echo "[entrypoint] warning: could not chown $d" >&2
-  fi
-done
+if [ "$ROOT" = 1 ]; then
+  # Deliberately NO usermod/groupmod. The base image already ships a user at uid 1000 (node), so renumbering
+  # the app user collides with it and the container crash-loops on "UID '1000' already exists" -- which is
+  # exactly what happened the first time this ran against a real library owned by uid 1000.
+  #
+  # su-exec takes numeric ids, and nothing in the app resolves its own username, so the app user simply does
+  # not need to own the number. Dropping this also drops the shadow dependency.
 
-# One line that answers "why did my rename fail" from `docker compose logs` alone, without anyone having to
-# exec into the container to find out which uid is running.
-if [ -d /library ]; then
-  if su-exec "$APP_UID:$APP_GID" test -w /library; then
-    echo "[entrypoint] uid $APP_UID: /library is writable, file operations are available"
-  else
-    lib_owner="$(stat -c '%u' /library 2>/dev/null || echo '?')"
-    echo "[entrypoint] uid $APP_UID: /library is READ-ONLY (owned by uid $lib_owner)."
-    echo "[entrypoint]   Renaming and deleting files is unavailable. To enable it, set PUID=$lib_owner"
-    echo "[entrypoint]   (and PGID to its group) in your .env and restart. Everything else works as normal."
+  # Only the volumes the app owns. NEVER /library: that is the user's collection, and taking ownership of it is
+  # the exact thing PUID exists to avoid.
+  #
+  # The recursion is conditional because /cache holds tens of thousands of files (61,336 / 11.3 GB on the
+  # instance this was written against) and a blind `chown -R` would stat every one of them on every single
+  # container start, to change nothing. /data is the embedded database's volume and is only ever created here.
+  for d in /config /library-dl /backups /cache /data; do
+    [ -d "$d" ] || continue
+    owner="$(stat -c '%u' "$d" 2>/dev/null || echo '')"
+    if [ "$owner" != "$APP_UID" ]; then
+      echo "[entrypoint] taking ownership of $d ($owner -> $APP_UID)"
+      chown -R "$APP_UID:$APP_GID" "$d" || echo "[entrypoint] warning: could not chown $d" >&2
+    fi
+  done
+
+  # One line that answers "why did my rename fail" from `docker compose logs` alone, without anyone having to
+  # exec into the container to find out which uid is running.
+  if [ -d /library ]; then
+    if su-exec "$APP_UID:$APP_GID" test -w /library; then
+      echo "[entrypoint] uid $APP_UID: /library is writable, file operations are available"
+    else
+      lib_owner="$(stat -c '%u' /library 2>/dev/null || echo '?')"
+      echo "[entrypoint] uid $APP_UID: /library is READ-ONLY (owned by uid $lib_owner)."
+      echo "[entrypoint]   Renaming and deleting files is unavailable. To enable it, set PUID=$lib_owner"
+      echo "[entrypoint]   (and PGID to its group) in your .env and restart. Everything else works as normal."
+    fi
   fi
+else
+  # Not root: someone set `user:` in compose, which bypasses this script's ability to adjust anything. Say so
+  # plainly and carry on rather than failing, because it is a legitimate way to run the container.
+  echo "[entrypoint] running as uid $(id -u); PUID/PGID ignored (the container was not started as root)"
 fi
 
-exec su-exec "$APP_UID:$APP_GID" "$@"
+if [ "$EMBEDDED" = 0 ]; then
+  # An external database: the path every install before embedded Postgres took, unchanged.
+  if [ "$ROOT" = 1 ]; then exec su-exec "$APP_UID:$APP_GID" "$@"; else exec "$@"; fi
+fi
+
+# ---------------------------------------------------------------- embedded -------------------------------
+# Socket only: listen_addresses is empty, so nothing outside this container can reach the database at all,
+# and there is no password to manage. The socket directory is /run/postgresql when this uid may write there
+# (root arranges it; the image pre-creates it for the default uid) and a temp directory otherwise.
+mkdir -p "$PGDATA" "$PGSOCK" 2>/dev/null || true
+if [ "$ROOT" = 1 ]; then
+  chown "$APP_UID:$APP_GID" "$PGDATA" "$PGSOCK"
+fi
+if ! as_app test -w "$PGSOCK" 2>/dev/null; then
+  PGSOCK=/tmp/pgsock
+  mkdir -p "$PGSOCK"
+fi
+if ! as_app test -w "$PGDATA" 2>/dev/null; then
+  echo "[entrypoint] $PGDATA is not writable by uid $(as_app id -u). The embedded database needs a writable /data volume." >&2
+  exit 1
+fi
+as_app chmod 700 "$PGDATA"
+
+# Postgres refuses to run as a uid with no passwd entry -- initdb says "could not look up effective user ID
+# 1003: user does not exist" -- and PUID is usually exactly that: the owner of the library, who exists on the
+# host and not in this image. That was the first thing the real boot found, after every fake had passed.
+# Two remedies, in order. As root, add an entry for the uid (adding, never renumbering: the comment above
+# about usermod stands, and a uid that already has an entry, like node's 1000, is left alone). Not root, or
+# if that fails, answer the lookup through nss_wrapper from a file, which is what the official postgres image
+# does for arbitrary --user values. Neither working is a real limit, and it is said plainly.
+ensure_passwd_entry() {
+  uid="$(as_app id -u)"; gid="$(as_app id -g)"
+  if getent passwd "$uid" >/dev/null 2>&1; then return 0; fi
+  if [ "$ROOT" = 1 ]; then
+    getent group "$gid" >/dev/null 2>&1 || addgroup -g "$gid" "app$gid" >/dev/null 2>&1 || true
+    grp="$(getent group "$gid" 2>/dev/null | cut -d: -f1)"
+    if adduser -D -H -u "$uid" -G "${grp:-nogroup}" "app$uid" >/dev/null 2>&1; then
+      echo "[entrypoint] added a passwd entry for uid $uid so Postgres can run as it"
+      return 0
+    fi
+  fi
+  nss="${NSS_WRAPPER_LIB:-/usr/lib/libnss_wrapper.so}"
+  if [ -f "$nss" ]; then
+    printf 'app%s:x:%s:%s:app:/tmp:/bin/sh\n' "$uid" "$uid" "$gid" > /tmp/nss-passwd
+    printf 'app%s:x:%s:\n' "$gid" "$gid" > /tmp/nss-group
+    export LD_PRELOAD="$nss" NSS_WRAPPER_PASSWD=/tmp/nss-passwd NSS_WRAPPER_GROUP=/tmp/nss-group
+    echo "[entrypoint] uid $uid has no passwd entry; Postgres will run as it through nss_wrapper"
+    return 0
+  fi
+  echo "[entrypoint] uid $uid has no passwd entry and nss_wrapper is not available, so Postgres cannot start as it." >&2
+  echo "[entrypoint]   Use PUID/PGID (the container then adds the entry) rather than 'user:', or set DATABASE_URL." >&2
+  return 1
+}
+ensure_passwd_entry || exit 1
+
+# A data directory from a different Postgres major cannot be opened by this server, and the error Postgres
+# gives for that is not one anyone should have to decode from a crash loop. Refuse up front and say where the
+# upgrade path is written down.
+SERVER_MAJOR="$(pg_ctl --version | sed -E 's/^.*\) ([0-9]+).*$/\1/')"
+if [ -s "$PGDATA/PG_VERSION" ]; then
+  DATA_MAJOR="$(cat "$PGDATA/PG_VERSION")"
+  if [ "$DATA_MAJOR" != "$SERVER_MAJOR" ]; then
+    echo "[entrypoint] the database in $PGDATA is Postgres $DATA_MAJOR and this image ships Postgres $SERVER_MAJOR." >&2
+    echo "[entrypoint]   It needs upgrading before it can be opened: see docs/MIGRATING.md#postgres-upgrade." >&2
+    exit 1
+  fi
+else
+  echo "[entrypoint] first start: initialising embedded Postgres $SERVER_MAJOR in $PGDATA"
+  # UTF-8 with C collation: musl has no real locales, so this is what the official alpine image gets too, and
+  # it is the ordering every existing install already has. --auth=trust is fine on a socket nobody else can
+  # reach; there is no network listener to protect.
+  as_app initdb -D "$PGDATA" -U yomi -E UTF8 --locale=C --auth=trust --auth-local=trust >/dev/null
+fi
+
+# The server's own log goes to the container log with the app's, rather than to a file inside the volume
+# that nothing rotates. Started with -w so the app never races a database that is still recovering.
+echo "[entrypoint] starting embedded Postgres $SERVER_MAJOR (socket $PGSOCK)"
+as_app pg_ctl -D "$PGDATA" -w -t 60 -l /dev/stdout \
+  -o "-c listen_addresses='' -k $PGSOCK -c log_min_messages=warning" start >/dev/null
+if ! as_app psql -h "$PGSOCK" -U yomi -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='yomi'" | grep -q 1; then
+  as_app createdb -h "$PGSOCK" -U yomi yomi
+fi
+
+export DATABASE_URL="postgres://yomi@/yomi?host=$PGSOCK"
+export EMBEDDED_DB=1
+# The healthcheck cannot see this shell's environment, so it reads a marker instead.
+: > "$PGSOCK/.embedded"
+
+# Supervise. The app runs in the background so this shell can forward SIGTERM to it (it finishes the chapter
+# it is writing; server.ts caps that itself) and then stop Postgres cleanly once it has gone. A watcher kills
+# the app if Postgres dies underneath it, so the container exits and gets restarted whole. The exit code is
+# the app's, so `docker ps` tells the truth about why the container stopped.
+stop_pg() {
+  echo "[entrypoint] stopping embedded Postgres"
+  as_app pg_ctl -D "$PGDATA" -m fast -w -t 30 stop >/dev/null 2>&1 || true
+  rm -f "$PGSOCK/.embedded"
+}
+# NOT through as_app: a shell function run in the background is a subshell, so $! would be the subshell and
+# a signal sent to it would never reach the app inside -- the app would be orphaned, still running, while
+# this script stopped Postgres underneath it. A plain background command forks straight into the app.
+# The app gets neither the preload nor the wrapper files: they exist for Postgres's user lookup alone.
+if [ "$ROOT" = 1 ]; then
+  env -u LD_PRELOAD -u NSS_WRAPPER_PASSWD -u NSS_WRAPPER_GROUP su-exec "$APP_UID:$APP_GID" "$@" &
+else
+  env -u LD_PRELOAD -u NSS_WRAPPER_PASSWD -u NSS_WRAPPER_GROUP "$@" &
+fi
+NODE=$!
+trap 'kill -TERM "$NODE" 2>/dev/null || true' TERM INT
+(
+  while kill -0 "$NODE" 2>/dev/null; do
+    sleep 5
+    if kill -0 "$NODE" 2>/dev/null && ! as_app pg_ctl -D "$PGDATA" status >/dev/null 2>&1; then
+      echo "[entrypoint] embedded Postgres has stopped; stopping the app so the container restarts whole" >&2
+      kill -TERM "$NODE" 2>/dev/null || true
+      break
+    fi
+  done
+) &
+WATCH=$!
+set +e
+wait "$NODE"; RC=$?
+# A signal interrupts wait before the child has exited; wait again to collect its real status.
+if [ "$RC" -gt 128 ]; then wait "$NODE"; RC=$?; fi
+set -e
+kill "$WATCH" 2>/dev/null || true
+stop_pg
+exit "$RC"

--- a/bff/openapi.yaml
+++ b/bff/openapi.yaml
@@ -6,7 +6,7 @@
 openapi: 3.1.0
 info:
   title: Uchiyomi API
-  version: 0.17.0
+  version: 0.18.0
   description: "Everything the web app does, it does over this API. Session JWTs are for the browser; scripts
     use a personal API token (Profile -> Security -> API tokens), sent as `Authorization: Bearer uy_...`.
     Scopes: read (every token), write (anything that changes data), admin (the /api/admin surface, which also

--- a/bff/openapi.yaml
+++ b/bff/openapi.yaml
@@ -6,7 +6,7 @@
 openapi: 3.1.0
 info:
   title: Uchiyomi API
-  version: 0.18.0
+  version: 0.19.0
   description: "Everything the web app does, it does over this API. Session JWTs are for the browser; scripts
     use a personal API token (Profile -> Security -> API tokens), sent as `Authorization: Bearer uy_...`.
     Scopes: read (every token), write (anything that changes data), admin (the /api/admin surface, which also

--- a/bff/package.json
+++ b/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yomi-bff",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/bff/package.json
+++ b/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yomi-bff",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/bff/src/routes/admin.ts
+++ b/bff/src/routes/admin.ts
@@ -1541,6 +1541,9 @@ export default async function adminRoutes(app: FastifyInstance) {
       lastScan: runtime.lastScan || null,
       members: members?.c ?? 0,
       backlog: { chapters: backlog?.chapters ?? 0, series: backlog?.series ?? 0 },
+      // Where the database lives. The entrypoint exports EMBEDDED_DB=1 only when it started Postgres itself
+      // (DATABASE_URL was unset); an install talking to its own database never sees the variable.
+      database: process.env.EMBEDDED_DB === '1' ? 'embedded' : 'external',
       activity,
     };
   });

--- a/bff/test/aioParity.test.ts
+++ b/bff/test/aioParity.test.ts
@@ -98,3 +98,37 @@ test('the root build context is pruned', () => {
     assert.match(ignore, new RegExp(needed.replace('.', '\\.')), `.dockerignore does not exclude ${needed}`);
   }
 });
+
+test('the single image can run its own Postgres, of the same major as its pg_dump', () => {
+  // Embedded mode (DATABASE_URL unset) needs the server package; the client is what pg_dump comes from. If
+  // the two majors ever differ, pg_dump writes archives the embedded server cannot restore -- the exact
+  // mismatch the backup task's plain-SQL choice was made to survive against an OLDER server, not a newer.
+  const aio = readFileSync(join(REPO, 'Dockerfile.aio'), 'utf8');
+  const apk = aio.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+  const server = /postgresql(\d+)(?![-\w])/.exec(apk);
+  const client = /postgresql(\d+)-client/.exec(apk);
+  assert.ok(server, 'Dockerfile.aio does not install the postgresql server package, so embedded mode cannot start');
+  assert.ok(client, 'Dockerfile.aio does not install the postgresql client');
+  assert.equal(server![1], client![1], `server is postgresql${server![1]}, client is postgresql${client![1]}-client`);
+  // The healthcheck must ask the database too when it is inside the container. Reintroduce by restoring
+  // the /livez-only check: a wedged embedded Postgres reads as healthy.
+  const hc = aio.slice(aio.indexOf('HEALTHCHECK'));
+  assert.match(hc, /pg_isready/, 'the container healthcheck ignores the embedded database');
+  assert.match(hc, /\.embedded/, 'the healthcheck cannot tell embedded from external, so it either always or never asks Postgres');
+  assert.match(aio, /mkdir -p [^\n]*\/data\b/, '/data is not created in the image, so the volume seeds as a root-owned mountpoint');
+  // Reintroduce by dropping nss_wrapper from the apk line: a container started with `user:` cannot run
+  // its database, because initdb refuses a uid with no passwd entry.
+  assert.match(apk, /\bnss_wrapper\b/, 'nss_wrapper is not installed, so embedded mode refuses any `user:` the image does not know');
+});
+
+test('the entrypoint owns the embedded database lifecycle, and only when asked', () => {
+  const ep = readFileSync(join(REPO, 'bff', 'docker-entrypoint.sh'), 'utf8');
+  const code = ep.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+  for (const needed of ['initdb', 'pg_ctl', 'PG_VERSION', 'listen_addresses', 'MIGRATING.md#postgres-upgrade', 'EMBEDDED_DB=1', 'nss_wrapper', 'adduser']) {
+    assert.ok(code.includes(needed), `docker-entrypoint.sh no longer mentions ${needed}`);
+  }
+  // The switch, spelled the one way that cannot misfire: an empty or unset DATABASE_URL.
+  assert.match(code, /\[ -z "\$\{DATABASE_URL:-\}" \]/, 'the embedded switch is no longer "DATABASE_URL unset"');
+  // The behaviour itself is driven in entrypointEmbedded.test.ts; this is the cheap guard that the file
+  // still carries the pieces that test relies on.
+});

--- a/bff/test/deployCompose.test.ts
+++ b/bff/test/deployCompose.test.ts
@@ -43,7 +43,7 @@ function suwayomiBlock(file: string): string {
 const instructions = (block: string): string =>
   block.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
 
-const FILES = ['deploy/docker-compose.yml', 'deploy/docker-compose.split.yml', 'docker-compose.yml'];
+const FILES = ['deploy/docker-compose.yml', 'deploy/docker-compose.external-db.yml', 'deploy/docker-compose.split.yml', 'docker-compose.yml'];
 
 test('the extension engine is told never to download into its own volume', () => {
   for (const file of FILES) {
@@ -83,4 +83,24 @@ test('the optional engine is not made mandatory by a depends_on', () => {
       assert.ok(!/suwayomi/.test(m[0]), `${file}: something depends_on the optional extension engine`);
     }
   }
+});
+
+test('the install file is one container, and the external-database file still is not', () => {
+  // deploy/docker-compose.yml is what the README tells people to curl. Since v0.18.0 it runs the database
+  // inside the container: no db service, no DATABASE_URL (that is the switch), a /data volume, and a grace
+  // period long enough for the app to finish a chapter and Postgres to checkpoint.
+  const one = instructions(readFileSync(join(REPO, 'deploy/docker-compose.yml'), 'utf8'));
+  // Reintroduce by pasting a DATABASE_URL back in: the embedded database silently never starts and the app
+  // waits forever for a host that is not there.
+  assert.ok(!/DATABASE_URL/.test(one), 'deploy/docker-compose.yml sets DATABASE_URL, which turns embedded mode off');
+  assert.ok(!/^\s{2}[a-z-]*-db:$/m.test(one), 'deploy/docker-compose.yml still runs a database container');
+  assert.match(one, /uchiyomi_data:\/data/, 'the embedded database has no volume, so it is lost on every recreate');
+  assert.match(one, /stop_grace_period:\s*[2-9]\d+s/, 'no stop_grace_period: docker kills Postgres mid-checkpoint at 10 s');
+  assert.ok(!/uchiyomi_pgdata/.test(one), 'a pgdata volume is declared for a database container that is not there');
+
+  // The external layout is still shipped, unchanged in substance, for people who run Postgres themselves.
+  const ext = instructions(readFileSync(join(REPO, 'deploy/docker-compose.external-db.yml'), 'utf8'));
+  assert.match(ext, /^\s{2}uchiyomi-db:$/m, 'the external-database file lost its database container');
+  assert.match(ext, /DATABASE_URL:\s*postgres:\/\//, 'the external-database file no longer points the app at its database');
+  assert.match(ext, /depends_on:[\s\S]{0,80}uchiyomi-db/, 'the app no longer waits for its database in the external layout');
 });

--- a/bff/test/entrypointEmbedded.test.ts
+++ b/bff/test/entrypointEmbedded.test.ts
@@ -38,6 +38,10 @@ esac; exit 0`);
   fake('psql', `[ -f "$PGDATA/.dbcreated" ] && echo 1 || echo ""`);
   fake('createdb', `touch "$PGDATA/.dbcreated"`);
   fake('pg_isready', 'exit 0');
+  // The passwd lookup is the test's to decide. On a GitHub runner the process uid HAS an entry, so without
+  // this the "no passwd entry" tests never reached the nss_wrapper path they assert on -- green locally
+  // (a container uid with no entry), red in CI. Found by CI; the fake answers "not found" unless told.
+  fake('getent', `[ -f "$FAKE_GETENT_FOUND" ] && { echo "app:x:$2:$2::/tmp:/bin/sh"; exit 0; }; exit 2`);
   // The "app": records its environment, optionally waits, optionally reports a signal, exits as told.
   fake('app', `env | grep -E '^(DATABASE_URL|EMBEDDED_DB|LD_PRELOAD)=' > "$FAKELOG.env"
 trap 'echo "app got TERM" >> "$FAKELOG"; exit 0' TERM
@@ -59,7 +63,7 @@ function run(sb: ReturnType<typeof sandbox>, env: Record<string, string | undefi
   const child = spawn('sh', [SCRIPT, sb.app], {
     env: {
       PATH: `${sb.bin}:${process.env.PATH}`, HOME: sb.root, FAKELOG: sb.log, PGDATA: sb.pgdata, PGSOCK: sb.sock, NSS_WRAPPER_LIB: sb.nss,
-      FAKE_PG_REFUSE_START: join(sb.root, 'refuse-start'),
+      FAKE_PG_REFUSE_START: join(sb.root, 'refuse-start'), FAKE_GETENT_FOUND: join(sb.root, 'getent-found'),
       ...Object.fromEntries(Object.entries(env).filter(([, v]) => v !== undefined) as [string, string][]),
     },
   });
@@ -128,6 +132,15 @@ test('a uid with no passwd entry is given one for Postgres, and the app is not p
   assert.match(r.initdbEnv, /NSS_WRAPPER_PASSWD=/, 'no passwd file was handed to nss_wrapper');
   assert.match(r.out, /no passwd entry; Postgres will run as it through nss_wrapper/);
   assert.equal(r.env.LD_PRELOAD, undefined, 'the preload leaked into the app');
+});
+
+test('a uid that already has a passwd entry needs no remedy', async () => {
+  const sb = sandbox();
+  writeFileSync(join(sb.root, 'getent-found'), '');
+  const r = await run(sb, { DATABASE_URL: undefined });
+  assert.equal(r.code, 0, r.err);
+  assert.ok(!/LD_PRELOAD/.test(r.initdbEnv), 'nss_wrapper was preloaded for a uid that has an entry');
+  assert.ok(!/passwd entry/.test(r.out + r.err), 'a remedy was announced for a uid that needs none');
 });
 
 test('with neither remedy available it refuses, and says what to do instead', async () => {

--- a/bff/test/entrypointEmbedded.test.ts
+++ b/bff/test/entrypointEmbedded.test.ts
@@ -1,0 +1,188 @@
+// The entrypoint runs a database when it is not given one, and only then.
+//
+// docker-entrypoint.sh is the whole one-container story: with DATABASE_URL unset it initialises Postgres in
+// /data/pg, starts it on a socket, points the app at it, forwards SIGTERM, and stops it after the app is gone.
+// With DATABASE_URL set it must do NONE of that -- every install before v0.18.0 has one set, and an
+// entrypoint that started a second Postgres beside their real one would be a very quiet disaster.
+//
+// Driven for real, as a shell script, with fake Postgres binaries on PATH that record their arguments. Not
+// as root, so the script takes its non-root branch; the root-only parts (chown, su-exec) are three lines
+// that the image build and the e2e run exercise. Everything else -- the trigger, the argument shapes, the
+// version guard, the ordering, the signal handling, the watchdog -- is here.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = join(__dirname, '..', 'docker-entrypoint.sh');
+
+/** A sandbox: fake binaries that log to FAKELOG, an empty PGDATA, a socket dir, and an "app" to run. */
+function sandbox() {
+  const root = mkdtempSync(join(tmpdir(), 'uchiyomi-entrypoint-'));
+  const bin = join(root, 'bin'); mkdirSync(bin);
+  const log = join(root, 'calls.log');
+  const fake = (name: string, body: string) => {
+    writeFileSync(join(bin, name), `#!/bin/sh\necho "${name} $*" >> "$FAKELOG"\n${body}\n`);
+    chmodSync(join(bin, name), 0o755);
+  };
+  fake('pg_ctl', `case " $* " in
+  *" --version "*) echo "pg_ctl (PostgreSQL) 16.15"; exit 0;;
+  *" start "*)  [ -f "$FAKE_PG_REFUSE_START" ] && exit 1; touch "$PGDATA/postmaster.pid"; exit 0;;
+  *" status "*) [ -f "$PGDATA/postmaster.pid" ] && exit 0 || exit 3;;
+  *" stop "*)   rm -f "$PGDATA/postmaster.pid"; exit 0;;
+esac; exit 0`);
+  // initdb records what it saw of the user lookup: the real one refuses a uid with no passwd entry.
+  fake('initdb', `env | grep -E '^(LD_PRELOAD|NSS_WRAPPER_PASSWD)=' > "$FAKELOG.initdb.env"; mkdir -p "$PGDATA" && echo 16 > "$PGDATA/PG_VERSION"`);
+  fake('psql', `[ -f "$PGDATA/.dbcreated" ] && echo 1 || echo ""`);
+  fake('createdb', `touch "$PGDATA/.dbcreated"`);
+  fake('pg_isready', 'exit 0');
+  // The "app": records its environment, optionally waits, optionally reports a signal, exits as told.
+  fake('app', `env | grep -E '^(DATABASE_URL|EMBEDDED_DB|LD_PRELOAD)=' > "$FAKELOG.env"
+trap 'echo "app got TERM" >> "$FAKELOG"; exit 0' TERM
+if [ -n "\${FAKE_SLEEP:-}" ]; then sleep "$FAKE_SLEEP" & wait $!; fi
+exit "\${FAKE_EXIT:-0}"`);
+  const pgdata = join(root, 'pg'); const sock = join(root, 'sock');
+  // A stand-in for libnss_wrapper.so. The test uid has no passwd entry in the runner's container either,
+  // so without this the non-root path has no remedy and refuses -- which is its own test below.
+  const nss = join(root, 'libnss_wrapper.so'); writeFileSync(nss, '');
+  return { root, bin, log, pgdata, sock, nss, app: join(bin, 'app') };
+}
+
+interface Run { code: number | null; signal: string | null; out: string; err: string; calls: string[]; env: Record<string, string>; initdbEnv: string; ms: number }
+
+function run(sb: ReturnType<typeof sandbox>, env: Record<string, string | undefined>, opts: { termAfterMs?: number; killPgAfterMs?: number } = {}): Promise<Run> {
+  const t0 = Date.now();
+  // The fakes append; a second run in the same sandbox must not read the first run's calls.
+  rmSync(sb.log, { force: true }); rmSync(`${sb.log}.env`, { force: true }); rmSync(`${sb.log}.initdb.env`, { force: true });
+  const child = spawn('sh', [SCRIPT, sb.app], {
+    env: {
+      PATH: `${sb.bin}:${process.env.PATH}`, HOME: sb.root, FAKELOG: sb.log, PGDATA: sb.pgdata, PGSOCK: sb.sock, NSS_WRAPPER_LIB: sb.nss,
+      FAKE_PG_REFUSE_START: join(sb.root, 'refuse-start'),
+      ...Object.fromEntries(Object.entries(env).filter(([, v]) => v !== undefined) as [string, string][]),
+    },
+  });
+  let out = '', err = '';
+  child.stdout.on('data', (d) => { out += d; });
+  child.stderr.on('data', (d) => { err += d; });
+  if (opts.termAfterMs) setTimeout(() => child.kill('SIGTERM'), opts.termAfterMs);
+  if (opts.killPgAfterMs) setTimeout(() => rmSync(join(sb.pgdata, 'postmaster.pid'), { force: true }), opts.killPgAfterMs);
+  return new Promise((resolve) => child.on('exit', (code, signal) => {
+    const calls = existsSync(sb.log) ? readFileSync(sb.log, 'utf8').trim().split('\n').filter(Boolean) : [];
+    const initdbEnv = existsSync(`${sb.log}.initdb.env`) ? readFileSync(`${sb.log}.initdb.env`, 'utf8') : '';
+    const envText = existsSync(`${sb.log}.env`) ? readFileSync(`${sb.log}.env`, 'utf8') : '';
+    const e: Record<string, string> = {};
+    for (const l of envText.split('\n')) { const i = l.indexOf('='); if (i > 0) e[l.slice(0, i)] = l.slice(i + 1); }
+    resolve({ code, signal, out, err, calls, env: e, initdbEnv, ms: Date.now() - t0 });
+  }));
+}
+const pgCalls = (r: Run) => r.calls.filter((c) => /^(pg_ctl|initdb|psql|createdb)/.test(c));
+
+test('with DATABASE_URL set, nothing about Postgres happens and the app gets that URL', async () => {
+  const sb = sandbox();
+  const r = await run(sb, { DATABASE_URL: 'postgres://u:p@db:5432/yomi' });
+  // Reintroduce by removing the `[ -z DATABASE_URL ]` switch: every existing install starts a second
+  // Postgres beside its real one, in a /data that does not exist, and the container fails to boot.
+  assert.equal(r.code, 0, r.err);
+  assert.deepEqual(pgCalls(r), [], 'a Postgres binary was called with an external database configured');
+  assert.equal(r.env.DATABASE_URL, 'postgres://u:p@db:5432/yomi');
+  assert.equal(r.env.EMBEDDED_DB, undefined, 'EMBEDDED_DB must not be set on the external path');
+  assert.ok(!existsSync(sb.pgdata), 'a data directory was created for a database that is not ours');
+});
+
+test('THE EMBEDDED PATH: initdb once, socket-only start, the app pointed at it, stop after the app exits', async () => {
+  const sb = sandbox();
+  const r = await run(sb, { DATABASE_URL: undefined, FAKE_EXIT: '3' });
+  assert.equal(r.code, 3, `the container must exit with the APP's code so docker ps tells the truth; got ${r.code}\n${r.err}`);
+  const init = r.calls.filter((c) => c.startsWith('initdb'));
+  assert.equal(init.length, 1, 'initdb must run exactly once on first start');
+  assert.match(init[0], new RegExp(`-D ${sb.pgdata}\\b`)); assert.match(init[0], /-U yomi\b/); assert.match(init[0], /--auth=trust/);
+  const start = r.calls.find((c) => /^pg_ctl .* start/.test(c))!;
+  assert.ok(start, 'pg_ctl start was never called');
+  // Reintroduce by dropping listen_addresses='': the database listens on TCP inside the container's network
+  // namespace with trust auth -- reachable by anything else on that network.
+  assert.match(start, /listen_addresses=''/, 'the embedded database must not listen on TCP');
+  assert.match(start, new RegExp(`-k ${sb.sock}\\b`), 'the socket directory must be the one the app is told about');
+  assert.match(start, /\s-w\b/, 'start must wait for the server, or the app races recovery');
+  assert.ok(r.calls.some((c) => c.startsWith('createdb')), 'the yomi database was never created');
+  assert.equal(r.env.DATABASE_URL, `postgres://yomi@/yomi?host=${sb.sock}`, 'the app was pointed somewhere else');
+  assert.equal(r.env.EMBEDDED_DB, '1');
+  const order = r.calls.map((c) => c.split(' ')[0]);
+  assert.ok(order.indexOf('app') > order.lastIndexOf('createdb'), 'the app started before the database was ready');
+  const stop = r.calls.findIndex((c) => /^pg_ctl .* stop/.test(c));
+  assert.ok(stop > order.indexOf('app'), 'Postgres was stopped before, or never after, the app');
+  assert.match(r.calls[stop], /-m fast/);
+  assert.ok(!existsSync(join(sb.sock, '.embedded')), 'the healthcheck marker outlived the database');
+});
+
+test('a uid with no passwd entry is given one for Postgres, and the app is not preloaded', async () => {
+  // The first thing the real boot found, after every fake had passed: initdb refuses "could not look up
+  // effective user ID 1003: user does not exist", and PUID is usually exactly such a uid. Not root here, so
+  // the remedy under test is nss_wrapper; the root path (adduser) is exercised by the image boot.
+  const sb = sandbox();
+  const r = await run(sb, { DATABASE_URL: undefined });
+  assert.equal(r.code, 0, r.err);
+  // Reintroduce by deleting ensure_passwd_entry: initdb runs bare and, on a real image, refuses.
+  assert.match(r.initdbEnv, new RegExp(`LD_PRELOAD=${sb.nss}`), 'initdb did not get the nss_wrapper preload');
+  assert.match(r.initdbEnv, /NSS_WRAPPER_PASSWD=/, 'no passwd file was handed to nss_wrapper');
+  assert.match(r.out, /no passwd entry; Postgres will run as it through nss_wrapper/);
+  assert.equal(r.env.LD_PRELOAD, undefined, 'the preload leaked into the app');
+});
+
+test('with neither remedy available it refuses, and says what to do instead', async () => {
+  const sb = sandbox();
+  rmSync(sb.nss);
+  const r = await run(sb, { DATABASE_URL: undefined });
+  assert.notEqual(r.code, 0, 'started Postgres as a uid it cannot run as');
+  assert.match(r.err, /no passwd entry and nss_wrapper is not available/);
+  assert.match(r.err, /PUID\/PGID/);
+  assert.ok(!r.calls.some((c) => c.startsWith('initdb')), 'initdb was attempted anyway');
+});
+
+test('a second start finds the data directory and does not initdb again', async () => {
+  const sb = sandbox();
+  await run(sb, { DATABASE_URL: undefined });
+  const r = await run(sb, { DATABASE_URL: undefined });
+  assert.equal(r.code, 0, r.err);
+  // Reintroduce by testing for the directory instead of PG_VERSION: mkdir -p runs first, so the directory
+  // always exists and initdb never runs -- or runs every time, destroying the data, depending on the guard.
+  assert.equal(r.calls.filter((c) => c.startsWith('initdb')).length, 0, 'initdb ran on an existing data directory');
+  assert.ok(r.calls.some((c) => /^pg_ctl .* start/.test(c)));
+});
+
+test('a data directory from another major is refused, with the upgrade path named', async () => {
+  const sb = sandbox();
+  mkdirSync(sb.pgdata, { recursive: true }); writeFileSync(join(sb.pgdata, 'PG_VERSION'), '15\n');
+  const r = await run(sb, { DATABASE_URL: undefined });
+  // Reintroduce by deleting the guard: Postgres 16 crash-loops on a 15 directory with an error nobody
+  // should have to decode from `docker logs`, and nothing says where the upgrade path is written down.
+  assert.notEqual(r.code, 0, 'a 15 data directory was opened by a 16 server');
+  assert.match(r.err, /Postgres 15/); assert.match(r.err, /Postgres 16/);
+  assert.match(r.err, /MIGRATING\.md#postgres-upgrade/, 'the refusal must say where the upgrade is documented');
+  assert.ok(!r.calls.some((c) => /^pg_ctl .* start/.test(c)), 'the server was started anyway');
+  assert.ok(!r.calls.some((c) => c.startsWith('app')), 'the app was started against a database that cannot open');
+});
+
+test('SIGTERM reaches the app first, and Postgres stops after it', async () => {
+  const sb = sandbox();
+  const r = await run(sb, { DATABASE_URL: undefined, FAKE_SLEEP: '30' }, { termAfterMs: 1500 });
+  // Reintroduce by exec'ing the app instead of supervising it: the shell is replaced, the trap is gone,
+  // and nothing stops Postgres -- docker kills it mid-checkpoint at the grace period.
+  assert.ok(r.calls.includes('app got TERM'), `the app never received SIGTERM:\n${r.calls.join('\n')}`);
+  const termAt = r.calls.indexOf('app got TERM');
+  const stopAt = r.calls.findIndex((c) => /^pg_ctl .* stop/.test(c));
+  assert.ok(stopAt > termAt, 'Postgres was stopped before the app had gone');
+  assert.equal(r.code, 0);
+  assert.ok(r.ms < 15000, `took ${r.ms} ms; the app was left to its 30 s sleep`);
+});
+
+test('if Postgres dies underneath the app, the app is stopped so the container restarts whole', async () => {
+  const sb = sandbox();
+  const r = await run(sb, { DATABASE_URL: undefined, FAKE_SLEEP: '60' }, { killPgAfterMs: 1500 });
+  // Reintroduce by deleting the watcher: the app keeps running against a dead socket, every request fails,
+  // and `restart: unless-stopped` never fires because the container never exits.
+  assert.match(r.err, /Postgres has stopped; stopping the app/);
+  assert.ok(r.calls.includes('app got TERM'), 'the app was not told');
+  assert.ok(r.ms < 20000, `took ${r.ms} ms; the watcher did not act`);
+});

--- a/bff/test/releasePipeline.test.ts
+++ b/bff/test/releasePipeline.test.ts
@@ -1,0 +1,105 @@
+// The release pipeline and the one-click manifests, held to the shape that stops them breaking.
+//
+// The pipeline broke four of five releases before v0.19.0, every time the same way: arm64 built under QEMU
+// on an amd64 runner, and the native-module builds either hung until the timeout or died with SIGILL. The
+// fix is structural -- each architecture on a runner of that architecture, merged into one index -- and
+// structural fixes are exactly the kind that get undone by a helpful edit ("let's simplify this back to one
+// job"). So the structure is pinned here, as text, the way aioParity.test.ts pins the Dockerfiles.
+//
+// The manifests are pinned for the same reason: an Unraid template with a missing path or an Umbrel compose
+// without the proxy block installs fine and then does not work, and nobody here runs Unraid or umbrelOS to
+// notice. What can be checked without them is checked.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+const REPO = join(__dirname, '..', '..');
+const read = (p: string) => readFileSync(join(REPO, p), 'utf8');
+const code = (s: string) => s.split('\n').filter((l) => !l.trim().startsWith('#')).join('\n');
+
+test('arm64 is built on an arm64 runner, never emulated, and merged into one index', () => {
+  const y = read('.github/workflows/release.yml');
+  const wf = parseYaml(y);
+  // Reintroduce by adding setup-qemu-action back: the next release hangs at exactly the timeout again.
+  assert.ok(!/setup-qemu/.test(code(y)), 'release.yml uses QEMU emulation again');
+  assert.match(code(y), /ubuntu-24\.04-arm/, 'no native arm64 runner');
+  assert.match(code(y), /push-by-digest=true/, 'architectures are not pushed by digest, so the tag can point at one of them');
+  assert.ok(wf.jobs.merge, 'no merge job: nothing writes the tag over both architectures');
+  assert.match(code(y), /imagetools create -t "\$\{\{ matrix\.image \}\}:\$\{\{ github\.ref_name \}\}"/, 'the merge job does not write the version tag');
+  assert.match(code(y), /grep -q "linux\/\$arch"/, 'the merge job does not check both architectures are in the index');
+  // The gate: latest moves only after every image is merged. Reintroduce by pointing `needs` at build.
+  assert.equal(wf.jobs.latest.needs, 'merge', 'latest is not gated on the merged indexes');
+  assert.equal(wf.jobs.merge.needs, 'build');
+  for (const j of ['build', 'merge', 'latest']) assert.ok(wf.jobs[j]['timeout-minutes'], `${j} has no timeout`);
+  assert.match(y, /attest-build-provenance/, 'no provenance attestation');
+  assert.equal(wf.permissions['id-token'], 'write', 'attestations need id-token: write');
+  assert.equal(wf.permissions.attestations, 'write');
+  // Every image, both architectures.
+  assert.deepEqual(wf.jobs.build.strategy.matrix.service, ['bff', 'web', 'aio']);
+  assert.deepEqual(wf.jobs.build.strategy.matrix.arch, ['amd64', 'arm64']);
+});
+
+test('dependencies and actions are watched weekly, grouped so CI is not run thirty times', () => {
+  const d = parseYaml(read('.github/dependabot.yml'));
+  const npm = d.updates.filter((u: any) => u['package-ecosystem'] === 'npm').map((u: any) => u.directory).sort();
+  assert.deepEqual(npm, ['/bff', '/web']);
+  for (const u of d.updates.filter((u: any) => u['package-ecosystem'] === 'npm')) {
+    assert.ok(u.groups && Object.keys(u.groups).length, `${u.directory}: npm updates are not grouped`);
+    assert.equal(u.schedule.interval, 'weekly');
+  }
+  assert.ok(d.updates.some((u: any) => u['package-ecosystem'] === 'github-actions'), 'actions are not watched');
+  const docker = d.updates.filter((u: any) => u['package-ecosystem'] === 'docker').map((u: any) => u.directory).sort();
+  assert.deepEqual(docker, ['/', '/bff', '/web'], 'not every Dockerfile has its base image watched');
+  const cq = parseYaml(read('.github/workflows/codeql.yml'));
+  assert.match(JSON.stringify(cq), /javascript-typescript/);
+  assert.equal(cq.permissions['security-events'], 'write');
+});
+
+test('the Unraid template names every volume, the ports, and the ids, and stops gracefully', () => {
+  const x = read('deploy/unraid/uchiyomi.xml');
+  assert.match(x, /<Repository>ghcr\.io\/angelosha\/uchiyomi<\/Repository>/);
+  assert.match(x, /<WebUI>http:\/\/\[IP\]:\[PORT:3000\]\/<\/WebUI>/, 'the WebUI link does not map the container port');
+  for (const target of ['/library', '/data', '/config', '/library-dl', '/cache', '/backups']) {
+    assert.match(x, new RegExp(`Target="${target}"[^>]*Type="Path"`), `no Path config for ${target}`);
+  }
+  for (const v of ['PUID', 'PGID', 'PUBLIC_ORIGIN']) assert.match(x, new RegExp(`Target="${v}"[^>]*Type="Variable"`), `no ${v} variable`);
+  assert.match(x, /Target="3000"[^>]*Type="Port"/, 'no port mapping for 3000');
+  // Reintroduce by deleting ExtraParams: Unraid stops the container with Docker's 10 s default and Postgres
+  // is killed mid-checkpoint on every "Update" and every array stop.
+  assert.match(x, /--stop-timeout 40/, 'no stop timeout for the embedded database');
+  // A Config element, not a mention: the template's own comment explains that DATABASE_URL is unset.
+  assert.ok(!/Target="DATABASE_URL"/.test(x), 'the template sets DATABASE_URL, which turns the embedded database off');
+  // Well-formed enough: every <Config ...> is closed on its own line.
+  const opens = (x.match(/<Config /g) || []).length, closes = (x.match(/<\/Config>/g) || []).length;
+  assert.equal(opens, closes, 'an unclosed <Config> element');
+});
+
+test('the Umbrel app has the proxy block, runs as 1000, pins by digest, and keeps its data', () => {
+  const m = parseYaml(read('deploy/umbrel/uchiyomi/umbrel-app.yml'));
+  assert.equal(m.manifestVersion, 1); assert.equal(m.id, 'uchiyomi'); assert.equal(m.port, 8080);
+  for (const k of ['name', 'tagline', 'description', 'developer', 'repo', 'support', 'category', 'version']) assert.ok(m[k], `manifest lacks ${k}`);
+  const c = parseYaml(read('deploy/umbrel/uchiyomi/docker-compose.yml'));
+  assert.ok(c.services.app_proxy, 'no app_proxy service: Umbrel cannot route to the app');
+  assert.equal(c.services.app_proxy.environment.APP_HOST, 'uchiyomi_server_1');
+  assert.equal(c.services.app_proxy.environment.APP_PORT, 3000);
+  const s = c.services.server;
+  assert.equal(s.user, '1000:1000', 'Umbrel runs apps as 1000:1000; the entrypoint takes its non-root path for that');
+  assert.match(s.image, /^ghcr\.io\/angelosha\/uchiyomi:v\d+\.\d+\.\d+@sha256:[0-9a-f]{64}$/, 'Umbrel requires the image pinned by digest');
+  assert.ok(!('DATABASE_URL' in (s.environment ?? {})), 'DATABASE_URL set: the embedded database is off and there is no other');
+  assert.ok(s.volumes.some((v: string) => v.endsWith(':/data')), 'no /data volume: the database is lost on every update');
+  assert.ok(s.volumes.some((v: string) => v.endsWith(':/library')), 'no library mount');
+  assert.match(String(s.stop_grace_period), /40s/);
+  // Umbrel manifests name a version; it must be the version the compose pins, or the store shows one thing
+  // and installs another.
+  assert.ok(s.image.includes(`:v${m.version}@`), `manifest version ${m.version} does not match the pinned image ${s.image}`);
+});
+
+test('the README tells Unraid and Umbrel users where their manifest is', () => {
+  const r = read('README.md');
+  // Written after the rebase onto stage 4, alongside the CasaOS line. Reintroduce by dropping either link.
+  assert.match(r, /deploy\/unraid\/uchiyomi\.xml/, 'README does not point Unraid users at the template');
+  assert.match(r, /deploy\/umbrel\/uchiyomi/, 'README does not point Umbrel users at the manifest');
+  assert.ok(existsSync(join(REPO, 'deploy/casaos/docker-compose.yml')), 'the CasaOS manifest moved');
+});

--- a/bff/test/releasePipeline.test.ts
+++ b/bff/test/releasePipeline.test.ts
@@ -29,6 +29,10 @@ test('arm64 is built on an arm64 runner, never emulated, and merged into one ind
   assert.ok(wf.jobs.merge, 'no merge job: nothing writes the tag over both architectures');
   assert.match(code(y), /imagetools create -t "\$\{\{ matrix\.image \}\}:\$\{\{ github\.ref_name \}\}"/, 'the merge job does not write the version tag');
   assert.match(code(y), /grep -q "linux\/\$arch"/, 'the merge job does not check both architectures are in the index');
+  // Reintroduce by piping `imagetools inspect` into grep -q or an early-exiting awk: buildx dies of SIGPIPE,
+  // pipefail makes that the step's status, and every merge fails after every build succeeded -- the first
+  // run of this pipeline, exactly.
+  assert.ok(!/imagetools inspect[^\n]*\|\s*(grep|awk|head)/.test(code(y)), 'release.yml pipes an imagetools inspect into a reader that can close the pipe early');
   // The gate: latest moves only after every image is merged. Reintroduce by pointing `needs` at build.
   assert.equal(wf.jobs.latest.needs, 'merge', 'latest is not gated on the merged indexes');
   assert.equal(wf.jobs.merge.needs, 'build');

--- a/deploy/docker-compose.external-db.yml
+++ b/deploy/docker-compose.external-db.yml
@@ -1,38 +1,55 @@
-# Uchiyomi, one container.
+# Uchiyomi, single container, with Postgres as its own container.
 #
-#   curl -O https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/docker-compose.yml
-#   docker compose up -d
+#   curl -O https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/docker-compose.external-db.yml
+#   docker compose -f docker-compose.external-db.yml up -d
 #
-# Then open http://localhost:8080 and create your admin account in the browser. There are no secrets to
-# generate, no config file to edit, and no database to run: Postgres lives inside the container, on a unix
-# socket, in the uchiyomi_data volume. Leave DATABASE_URL unset and that is what you get; set it and the
-# same image talks to a database you run yourself instead (docker-compose.external-db.yml is that layout,
-# ready to use). The two share every other volume, and docs/MIGRATING.md has the move in both directions.
+# This was the layout the install instructions used until v0.18.0. It still works, is still supported, and
+# is the right choice when you want the database in a container you manage yourself -- or already have one.
+# The layout the docs now lead with is docker-compose.yml: one container, with Postgres inside it on a unix
+# socket. See docs/MIGRATING.md to move between them; it is a dump and a restore, and both directions are
+# written down.
+#
+# An existing install keeps using this file. Nothing here changed except this header.
 #
 # The extension engine is still opt-in and still its own container, because it is a JVM. Leave it out and
-# the whole thing is one container plus the Cloudflare solver.
+# this is two containers total.
 #
 #   LIBRARY_PATH=/mnt/media/comics   your existing library (default: ./library)
 #   PUID= / PGID=                    run as the user that OWNS your library, so Uchiyomi can rename and
 #                                    delete files in it. `id -u` and `id -g`. Leave both unset and nothing
 #                                    changes: the app runs as uid 10002 and your library is read-only.
 #   WEB_PORT=8080                    the port you open in a browser
+#   DB_PASSWORD=...                  only used inside the private network; the DB has no published port
 
 services:
+  uchiyomi-db:
+    image: postgres:16-alpine
+    container_name: uchiyomi-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: yomi
+      POSTGRES_USER: yomi
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-uchiyomi}
+    volumes:
+      - uchiyomi_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U yomi -d yomi"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks: [uchiyomi_internal]
+
   uchiyomi:
     image: ghcr.io/angelosha/uchiyomi:latest
     container_name: uchiyomi
     restart: unless-stopped
-    # The app finishes the chapter it is writing on SIGTERM (up to 20 s), and then Postgres checkpoints and
-    # stops. Docker's default 10 s would kill the database mid-checkpoint.
-    stop_grace_period: 40s
     environment:
       # Run as the owner of your library so file operations work. Unset = uid 10002, library read-only.
       PUID: ${PUID:-}
       PGID: ${PGID:-}
       NODE_ENV: production
       PORT: "3000"
-      # No DATABASE_URL: that is the switch. Set one here and the embedded database is not started.
+      DATABASE_URL: postgres://yomi:${DB_PASSWORD:-uchiyomi}@uchiyomi-db:5432/yomi
       LIBRARY_BACKEND: ${LIBRARY_BACKEND:-owned}
       PUBLIC_ORIGIN: ${PUBLIC_ORIGIN:-http://localhost:8080}
       FLARESOLVERR_URL: http://uchiyomi-flaresolverr:8191
@@ -60,14 +77,16 @@ services:
     volumes:
       - ${LIBRARY_PATH:-./library}:/library      # your existing comics (see PUID above)
       - ${SOURCES_PATH:-./sources}:/sources:ro   # optional built source pack
-      - uchiyomi_data:/data                      # the embedded database (Postgres, in /data/pg)
       - uchiyomi_downloads:/library-dl           # chapters Uchiyomi downloads
       - uchiyomi_config:/config                  # secrets, custom sites, art overrides
       - uchiyomi_cache:/cache                    # image cache (safe to delete)
       - ${BACKUP_PATH:-uchiyomi_backups}:/backups
     ports:
       - "${WEB_PORT:-8080}:3000"
-    networks: [uchiyomi_app]
+    depends_on:
+      uchiyomi-db:
+        condition: service_healthy
+    networks: [uchiyomi_internal, uchiyomi_app]
 
   # Cloudflare solver. Most manga aggregators sit behind Cloudflare, so the fetching half needs this.
   uchiyomi-flaresolverr:
@@ -126,10 +145,11 @@ services:
       start_period: 90s
 
 networks:
+  uchiyomi_internal:   # database only — deliberately not reachable from outside the stack
   uchiyomi_app:
 
 volumes:
-  uchiyomi_data:       # the embedded database; back it up like any other volume, or rely on the nightly dump in /backups
+  uchiyomi_pgdata:
   uchiyomi_downloads:
   uchiyomi_config:
   uchiyomi_cache:

--- a/deploy/umbrel/uchiyomi/docker-compose.yml
+++ b/deploy/umbrel/uchiyomi/docker-compose.yml
@@ -1,0 +1,34 @@
+# Umbrel runs every app container as user 1000:1000 and fronts it with its own proxy. The image's entrypoint
+# takes the non-root path: no PUID/PGID, /data must be writable by 1000 (APP_DATA_DIR is), and Postgres runs
+# as 1000 through nss_wrapper because the image has no passwd entry for it.
+#
+# Umbrel requires the image pinned by digest. The digest is the one release.yml prints for
+# ghcr.io/angelosha/uchiyomi at this version (the "merge aio" job's notice); update it with each version.
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: uchiyomi_server_1
+      APP_PORT: 3000
+
+  server:
+    image: ghcr.io/angelosha/uchiyomi:v0.19.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 40s
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+      LIBRARY_BACKEND: owned
+      PUBLIC_ORIGIN: http://${DEVICE_DOMAIN_NAME}:8080
+      SOURCES_DIR: /sources
+      CUSTOM_SITES_FILE: /config/sites.json
+      BACKUP_KEEP: "14"
+    volumes:
+      - ${UMBREL_ROOT}/data/storage/uchiyomi/library:/library
+      - ${APP_DATA_DIR}/data:/data
+      - ${APP_DATA_DIR}/config:/config
+      - ${APP_DATA_DIR}/downloads:/library-dl
+      - ${APP_DATA_DIR}/cache:/cache
+      - ${APP_DATA_DIR}/backups:/backups

--- a/deploy/umbrel/uchiyomi/umbrel-app.yml
+++ b/deploy/umbrel/uchiyomi/umbrel-app.yml
@@ -1,0 +1,33 @@
+# Umbrel app manifest. Submitted as a PR to getumbrel/umbrel-apps; this copy is the source of truth.
+# Unverified on umbrelOS itself at the time of writing -- see the CHANGELOG entry that added it.
+manifestVersion: 1
+id: uchiyomi
+category: media
+name: Uchiyomi
+version: "0.19.0"
+tagline: A self-hosted manga and manhwa reader that also keeps up with new chapters
+description: >-
+  Uchiyomi is a self-hosted manga and manhwa reader that also fetches new chapters: discover, grab, monitor,
+  serve and read in one place. Point it at a folder of CBZ/CBR files and read them on any device through a
+  true-black OLED interface built webtoon-first, with continuous vertical scroll across chapters, pinch zoom
+  and double-page spreads for classic manga. It installs as a PWA, works offline, and keeps per-user reading
+  progress, favourites and history for a household. Two-factor auth, an audit log, nightly backups, no
+  account, no telemetry: your library stays yours. The database runs inside the container.
+developer: AngeloSha
+website: https://uchiyomi.com
+dependencies: []
+repo: https://github.com/AngeloSha/uchiyomi
+support: https://github.com/AngeloSha/uchiyomi/issues
+port: 8080
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+releaseNotes: >-
+  One container with its own database, OPDS page streaming for external readers, an API reference at
+  /api/docs, and extensions that keep themselves up to date.
+submitter: AngeloSha
+submission: https://github.com/getumbrel/umbrel-apps/pull/TODO

--- a/deploy/unraid/uchiyomi.xml
+++ b/deploy/unraid/uchiyomi.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+  Unraid Community Applications template. One container: the database runs inside it (DATABASE_URL unset),
+  in the Data path below. Submit to a CA template repository, or add this file's raw URL under
+  Docker -> Add Container -> Template repositories.
+-->
+<Container version="2">
+  <Name>uchiyomi</Name>
+  <Repository>ghcr.io/angelosha/uchiyomi</Repository>
+  <Registry>https://github.com/AngeloSha/uchiyomi/pkgs/container/uchiyomi</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/AngeloSha/uchiyomi/issues</Support>
+  <Project>https://uchiyomi.com</Project>
+  <Overview>A self-hosted manga and manhwa reader that also fetches new chapters: discover, grab, monitor, serve and read in one container. Point it at a folder of CBZ/CBR files and read them on any device through a true-black OLED interface built webtoon-first. Installs as a PWA, works offline, per-user progress and favourites, two-factor auth, nightly backups, no account, no telemetry. The database runs inside the container; there is nothing else to install.</Overview>
+  <Category>MediaServer:Books MediaApp:Books</Category>
+  <WebUI>http://[IP]:[PORT:3000]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/unraid/uchiyomi.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/web/public/icons/icon-512.png</Icon>
+  <!-- The app finishes the chapter it is writing on stop, then Postgres checkpoints; Docker's default 10 s would cut that short. -->
+  <ExtraParams>--stop-timeout 40</ExtraParams>
+  <DonateText>Support development</DonateText>
+  <DonateLink>https://github.com/sponsors/AngeloSha</DonateLink>
+  <Config Name="Web UI port" Target="3000" Default="8080" Mode="tcp" Description="The port you open in a browser." Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+  <Config Name="Library" Target="/library" Default="/mnt/user/media/comics" Mode="rw" Description="Your existing CBZ/CBR library. Any folder layout works. Set PUID/PGID to the owner of these files for renames and deletes; otherwise it is read-only." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/media/comics</Config>
+  <Config Name="Data (embedded database)" Target="/data" Default="/mnt/user/appdata/uchiyomi/data" Mode="rw" Description="Postgres lives here. Back it up like any appdata, or rely on the nightly dump in Backups." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/uchiyomi/data</Config>
+  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/uchiyomi/config" Mode="rw" Description="Secrets, custom sites, art overrides." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/uchiyomi/config</Config>
+  <Config Name="Downloads" Target="/library-dl" Default="/mnt/user/appdata/uchiyomi/downloads" Mode="rw" Description="Chapters Uchiyomi fetches from sources." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/uchiyomi/downloads</Config>
+  <Config Name="Image cache" Target="/cache" Default="/mnt/user/appdata/uchiyomi/cache" Mode="rw" Description="Safe to delete." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/uchiyomi/cache</Config>
+  <Config Name="Backups" Target="/backups" Default="/mnt/user/appdata/uchiyomi/backups" Mode="rw" Description="Nightly database and config dumps. Ideally a different disk from Data." Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/uchiyomi/backups</Config>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="Run as this user id (Unraid's nobody is 99). Use the owner of your library to allow renames and deletes." Type="Variable" Display="always" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Run as this group id (Unraid's users is 100)." Type="Variable" Display="always" Required="false" Mask="false">100</Config>
+  <Config Name="PUBLIC_ORIGIN" Target="PUBLIC_ORIGIN" Default="" Mode="" Description="How you reach it, e.g. http://192.168.1.10:8080 or https://manga.example.com. Must match, or logins and cookies break." Type="Variable" Display="always" Required="true" Mask="false"></Config>
+  <Config Name="FLARESOLVERR_URL" Target="FLARESOLVERR_URL" Default="" Mode="" Description="A FlareSolverr instance for Cloudflare-protected sources, e.g. http://192.168.1.10:8191. Optional." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="SUWAYOMI_URL" Target="SUWAYOMI_URL" Default="" Mode="" Description="A Suwayomi server for Mihon/Tachiyomi extensions, e.g. http://192.168.1.10:4567. Leave empty to go without extensions." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="BACKUP_KEEP" Target="BACKUP_KEEP" Default="14" Mode="" Description="How many nightly backups to keep." Type="Variable" Display="advanced" Required="false" Mask="false">14</Config>
+</Container>

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -1,3 +1,100 @@
+# Moving between layouts
+
+Uchiyomi runs in one of three shapes, all on the same image and the same volumes:
+
+| | containers | the database |
+| --- | --- | --- |
+| **one container** (`deploy/docker-compose.yml`, the default since v0.18.0) | `uchiyomi` | inside the container, on a unix socket, in the `uchiyomi_data` volume |
+| external database (`deploy/docker-compose.external-db.yml`) | `uchiyomi` + `uchiyomi-db` | a Postgres container you run |
+| split (`deploy/docker-compose.split.yml`) | `uchiyomi-bff` + `uchiyomi-web` + `uchiyomi-db` | a Postgres container you run |
+
+**You do not have to move.** Every layout keeps working and every image keeps being published. The one
+thing that decides which database is used is `DATABASE_URL`: set, the container talks to it; unset, the
+container starts a Postgres of its own. An existing install never drifts into the embedded one by accident.
+
+- [One container, no database container](#one-container-no-database-container)
+- [External database → one container](#external-database--one-container)
+- [One container → external database](#one-container--external-database)
+- [Upgrading the embedded Postgres major](#postgres-upgrade)
+- [From the split layout to one container](#moving-from-the-split-layout-to-one-container)
+
+## One container, no database container
+
+Leave `DATABASE_URL` unset and the entrypoint runs Postgres 16 inside the container: data in `/data/pg` (the
+`uchiyomi_data` volume), a unix socket only -- there is no network listener, so nothing outside the
+container can reach it and there is no password to manage -- and the app pointed at it before it starts.
+Postgres logs into the container log alongside the app's. On `docker stop` the app finishes what it is
+writing and then Postgres stops cleanly; the compose file sets `stop_grace_period: 40s` for that, because
+Docker's default ten seconds would kill a checkpoint. If Postgres ever dies underneath the app, the container
+exits and `restart: unless-stopped` brings both halves back in order.
+
+Everything else is identical: the same environment, the same `/config`, `/cache`, `/library-dl` and
+`/backups`, the same nightly backup task -- it dumps the embedded database exactly as it dumped an external
+one, into `/backups`. Back up the `uchiyomi_data` volume like any other, or rely on that dump.
+
+`PUID`/`PGID` apply to the database too: it runs as the same uid as the app, and the entrypoint takes
+ownership of `/data` the way it does the other app-owned volumes. Postgres insists that the uid it runs as
+has a passwd entry, and the owner of your library normally has none inside the image, so the entrypoint adds
+one. A container started with `user:` instead cannot be given an entry, so the lookup is answered through
+`nss_wrapper` the way the official Postgres image does it; such a container must also be given a `/data` it
+can write.
+
+## External database → one container
+
+A dump and a restore. The nightly backup is already the right format (plain SQL, gzipped), so if last
+night's is recent enough you can skip the first step and use it.
+
+```bash
+# 1. dump, while the old stack is still up (or take the newest file from your /backups volume)
+docker compose -f docker-compose.external-db.yml exec uchiyomi-db \
+  pg_dump -U yomi --no-owner --no-acl --clean --if-exists yomi | gzip > uchiyomi.sql.gz
+
+# 2. stop the old stack. This does NOT touch volumes.
+docker compose -f docker-compose.external-db.yml down
+
+# 3. take the one-container file and start it once, so the embedded database is initialised
+curl -O https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/docker-compose.yml
+docker compose up -d
+docker compose logs uchiyomi | grep -m1 'embedded Postgres'     # "starting embedded Postgres 16"
+
+# 4. restore into it, over the socket, then restart so the app sees your data
+gunzip -c uchiyomi.sql.gz | docker compose exec -T uchiyomi \
+  psql -q "postgres://yomi@/yomi?host=/run/postgresql"
+docker compose restart uchiyomi
+```
+
+Open the app: same accounts, same progress, same library. The old `uchiyomi_pgdata` volume is untouched;
+delete it once you are happy (`docker volume rm <project>_uchiyomi_pgdata`).
+
+## One container → external database
+
+The reverse: dump over the socket, start the external layout, restore into its database.
+
+```bash
+docker compose exec -T uchiyomi pg_dump --no-owner --no-acl --clean --if-exists \
+  "postgres://yomi@/yomi?host=/run/postgresql" | gzip > uchiyomi.sql.gz
+docker compose down
+curl -O https://raw.githubusercontent.com/AngeloSha/uchiyomi/main/deploy/docker-compose.external-db.yml
+docker compose -f docker-compose.external-db.yml up -d uchiyomi-db
+gunzip -c uchiyomi.sql.gz | docker compose -f docker-compose.external-db.yml exec -T uchiyomi-db psql -q -U yomi yomi
+docker compose -f docker-compose.external-db.yml up -d
+```
+
+## Postgres upgrade
+
+The image pins one Postgres major (16 today). A data directory written by a different major cannot be
+opened by it, and rather than crash-loop on Postgres's own error the entrypoint refuses to start and prints:
+
+```
+the database in /data/pg is Postgres 16 and this image ships Postgres 17.
+  It needs upgrading before it can be opened: see docs/MIGRATING.md#postgres-upgrade.
+```
+
+When Uchiyomi moves to a new major, the release notes will say so, and that release will ship as a
+transition image carrying both majors that runs `pg_upgrade` on first boot. Until then, the upgrade path is
+the dump-and-restore above: dump with the old image, start the new one on an empty `uchiyomi_data` volume,
+restore. Nothing about your data is lost either way; the guard exists so that nothing is lost by surprise.
+
 # Moving from the split layout to one container
 
 Uchiyomi used to run as two containers: `uchiyomi-bff` (the API) and `uchiyomi-web` (nginx serving the web

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -129,6 +129,8 @@ function AdminHero({ onBack }: { onBack: () => void; onScan?: undefined }) {
     stats ? tr('{n} series', { n: stats.seriesTotal }) : null,
     stats ? (stats.members === 1 ? tr('1 member') : tr('{n} members', { n: stats.members })) : null,
     stats ? tr('{size} cached', { size: bytes(stats.cacheBytes) }) : null,
+    // Which layout this is, in one word: the answer to "where is my database" without reading a compose file.
+    stats?.database ? (stats.database === 'embedded' ? tr('embedded database') : tr('external database')) : null,
     stats?.lastScan ? tr('scanned {when}', { when: relativeTime(new Date(stats.lastScan).toISOString()) }) : null,
     // From what the sources said the last time the updater asked. Absent until a sweep has stamped it.
     stats?.backlog?.chapters

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yomi-web",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yomi-web",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/test/e2e/run.mjs
+++ b/web/test/e2e/run.mjs
@@ -28,6 +28,13 @@ mkdirSync(OUT, { recursive: true });
 const fails = [];
 const consoleErrors = [];
 const serverErrors = [];
+// A cover proxied from a third-party CDN that answered the proxy with an error is not this app failing.
+// /img/sources/cover fetches whatever URL a source or AniList gave it; when that upstream refuses or falls
+// over -- which a GitHub runner's IP invites -- the route answers 5xx on purpose, so the browser's <img> can
+// fall back to the direct URL. That is the documented design, and it turned a passing run (40/40) into a red
+// badge on 2026-09-04 over one AniList cover. Noted, not counted; every other 5xx and console error still is.
+const thirdPartyCover = (url) => /\/img\/sources\/cover\?[^ ]*\bu=https?%3A/i.test(url || '');
+const thirdPartyNotes = [];
 let step = 0;
 
 const ok = (what) => console.log(`    [ ok ] ${what}`);
@@ -44,9 +51,16 @@ try {
   await page.setViewport({ width: 1440, height: 900 });
   page.on('console', (m) => {
     // A 401 on /auth/me before signing in is expected noise, not a fault.
-    if (m.type() === 'error' && !/401|auth\/me/.test(m.text())) consoleErrors.push(`${page.url()} :: ${m.text()}`);
+    if (m.type() === 'error' && !/401|auth\/me/.test(m.text())) {
+      if (thirdPartyCover(m.location()?.url)) thirdPartyNotes.push(`console @ ${page.url()}: ${m.location().url}`);
+      else consoleErrors.push(`${page.url()} :: ${m.text()}`);
+    }
   });
-  page.on('response', (r) => { if (r.status() >= 500) serverErrors.push(`${r.status()} ${r.request().method()} ${r.url()}`); });
+  page.on('response', (r) => {
+    if (r.status() < 500) return;
+    if (thirdPartyCover(r.url())) thirdPartyNotes.push(`${r.status()} ${r.url()}`);
+    else serverErrors.push(`${r.status()} ${r.request().method()} ${r.url()}`);
+  });
 
   const shot = async (name) => page.screenshot({ path: `${OUT}/${String(++step).padStart(2, '0')}-${name}.png` });
 
@@ -477,5 +491,9 @@ console.log(`${fails.length} failure(s), ${consoleErrors.length} console error(s
 for (const f of fails) console.log(`  ${f}`);
 for (const c of [...new Set(consoleErrors)].slice(0, 10)) console.log(`  console: ${c.slice(0, 160)}`);
 for (const s of [...new Set(serverErrors)].slice(0, 10)) console.log(`  server:  ${s.slice(0, 160)}`);
+if (thirdPartyNotes.length) {
+  console.log(`  ${thirdPartyNotes.length} third-party cover(s) failed upstream (noted, not counted):`);
+  for (const n of [...new Set(thirdPartyNotes)].slice(0, 5)) console.log(`    ${n.slice(0, 160)}`);
+}
 writeFileSync(`${OUT}/result.json`, JSON.stringify({ fails, consoleErrors, serverErrors }, null, 2));
 process.exit(fails.length || consoleErrors.length || serverErrors.length ? 1 : 0);

--- a/web/test/e2e/up.sh
+++ b/web/test/e2e/up.sh
@@ -6,6 +6,10 @@
 #
 #   bash web/test/e2e/up.sh              # build, run, clean up
 #   KEEP=1 bash web/test/e2e/up.sh       # leave it running to poke at
+#   E2E_EMBEDDED=1 bash web/test/e2e/up.sh   # no Postgres container: the image runs its own (DATABASE_URL unset)
+#
+# The embedded leg is the proof that the one-container layout behaves like the two-container one, in the
+# only place both are actually driven end to end. CI runs both.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -22,13 +26,16 @@ DB="$NET-db"
 SUBNET=${E2E_SUBNET:-10.222.0.0/24}
 USER=${E2E_USER:-e2e}
 PASS=${E2E_PASS:-e2e-passw0rd-123}
+EMBEDDED=${E2E_EMBEDDED:-0}
 LIB=$(mktemp -d)
+DATA=$(mktemp -d)
 
 cleanup() {
-  [ "${KEEP:-0}" = "1" ] && { echo "kept: $NET on :$PORT (library $LIB)"; return; }
+  [ "${KEEP:-0}" = "1" ] && { echo "kept: $NET on :$PORT (library $LIB, data $DATA)"; return; }
   docker rm -f "$APP" "$DB" >/dev/null 2>&1 || true
   docker network rm "$NET" >/dev/null 2>&1 || true
-  rm -rf "$LIB"
+  # /data is written by the container as PUID (our own uid), so a plain rm works.
+  rm -rf "$LIB" "$DATA"
 }
 trap cleanup EXIT INT TERM
 
@@ -42,16 +49,25 @@ docker rm -f "$APP" "$DB" >/dev/null 2>&1 || true
 docker network rm "$NET" >/dev/null 2>&1 || true
 docker network create --subnet "$SUBNET" "$NET" >/dev/null
 
-docker run -d --name "$DB" --network "$NET" \
-  -e POSTGRES_PASSWORD=e2e -e POSTGRES_DB=yomi postgres:16-alpine >/dev/null
-for _ in $(seq 1 60); do docker exec "$DB" pg_isready -q 2>/dev/null && break; sleep 1; done
+if [ "$EMBEDDED" = "1" ]; then
+  echo "· embedded database: no Postgres container, DATABASE_URL unset, /data mounted"
+  docker run -d --name "$APP" --network "$NET" -p "127.0.0.1:$PORT:3000" \
+    -e JWT_SECRET='e2e-secret-at-least-16-chars' \
+    -e LIBRARY_BACKEND=owned \
+    -e PUID="$(id -u)" -e PGID="$(id -g)" \
+    -v "$LIB":/library -v "$DATA":/data uchiyomi:e2e >/dev/null
+else
+  docker run -d --name "$DB" --network "$NET" \
+    -e POSTGRES_PASSWORD=e2e -e POSTGRES_DB=yomi postgres:16-alpine >/dev/null
+  for _ in $(seq 1 60); do docker exec "$DB" pg_isready -q 2>/dev/null && break; sleep 1; done
 
-docker run -d --name "$APP" --network "$NET" -p "127.0.0.1:$PORT:3000" \
-  -e DATABASE_URL="postgres://postgres:e2e@$DB:5432/yomi" \
-  -e JWT_SECRET='e2e-secret-at-least-16-chars' \
-  -e LIBRARY_BACKEND=owned \
-  -e PUID="$(id -u)" -e PGID="$(id -g)" \
-  -v "$LIB":/library uchiyomi:e2e >/dev/null
+  docker run -d --name "$APP" --network "$NET" -p "127.0.0.1:$PORT:3000" \
+    -e DATABASE_URL="postgres://postgres:e2e@$DB:5432/yomi" \
+    -e JWT_SECRET='e2e-secret-at-least-16-chars' \
+    -e LIBRARY_BACKEND=owned \
+    -e PUID="$(id -u)" -e PGID="$(id -g)" \
+    -v "$LIB":/library uchiyomi:e2e >/dev/null
+fi
 
 echo "· waiting for it to come up"
 for _ in $(seq 1 90); do


### PR DESCRIPTION
Two releases, stacked, from the staged roadmap.

**v0.18.0 — one container, database included.** `DATABASE_URL` unset = the container runs its own Postgres on a unix socket in `/data`. `deploy/docker-compose.yml` becomes one container; the external-database layout is kept as `docker-compose.external-db.yml` with the move documented in both directions. The entrypoint supervises both processes, forwards SIGTERM, guards the Postgres major, and gives the uid a passwd entry (or nss_wrapper) so Postgres will run as it. The browser e2e suite now drives both layouts.

**v0.19.0 — releases built on the machine they run on.** Per-architecture native runners merged into one index, provenance + SBOM attestations, Dependabot, CodeQL, Unraid and Umbrel manifests.

Why a PR rather than a push: the compose file at `deploy/docker-compose.yml` on `main` is what new installs `curl`, and the one-container form needs an image that supports it. So: CI here → tag `v0.18.0` at de57185 and `v0.19.0` at the tip → images publish → fast-forward `main`. No window where the file points at an image that cannot run it.

Full bff suite on the stage 4 tree: see the run summary in the commits; static/no-DB tests on the tip: 33/33; the image was built and booted for real (embedded with PUID, stopped, restarted with data kept, non-root, external path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)