### PR TITLE
Revise Unraid installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,11 @@ as a custom app and it appears with an icon like any store app. That manifest le
 engine, so Mihon/Tachiyomi extensions are off there; add `uchiyomi-suwayomi` from
 [`deploy/docker-compose.yml`](deploy/docker-compose.yml) and set `SUWAYOMI_URL` if you want them.
 
-**On Unraid?** Add `https://github.com/AngeloSha/unraid-templates` under *Docker → Add Container →
-Template repositories* and pick *uchiyomi* (a Community Applications listing is requested). One container,
-database included; set PUID/PGID to the owner of your library for renames. The template is mirrored here as
+**On Unraid?** 
+Add `https://github.com/AngeloSha/unraid-templates` to
+`/boot/config/plugins/dockerMan/template-repos`, then go to *Docker → Add Container* and select *uchiyomi*
+from the template dropdown (a Community Applications listing is requested). One container, database included;
+set PUID/PGID to the owner of your library for renames. The template is mirrored here as
 [`deploy/unraid/uchiyomi.xml`](deploy/unraid/uchiyomi.xml).
 
 **On Umbrel?** Uchiyomi is [submitted to the Umbrel App Store](https://github.com/getumbrel/umbrel-apps/pull/6055); until it is listed, the package at


### PR DESCRIPTION
Updated instructions for Unraid installation to reflect new configuration steps.

<!-- Thanks for contributing to Uchiyomi! Keep PRs focused: one topic per PR. -->

## Summary
Updates the Unraid installation instructions to reflect the current method for adding custom Docker template repositories.

## Type
- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

## Testing
Verified the updated instructions against a current Unraid installation.

## Checklist
- [x] Focused scope (one topic)
- [x] Matches the existing TypeScript style
- [x] Docs updated if user-facing (`docs/USAGE.md`)
- [x] No new default sources hardcoded to specific sites (the engine system reaches sites by URL)