### PR TITLE
Update INSTALL.md to remove uchiyomi-db entry

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,7 +71,6 @@ What you end up running:
 | Container | Role |
 |---|---|
 | `uchiyomi` | the app: the API and the PWA it serves |
-| `uchiyomi-db` | private Postgres (no published port — unreachable from outside the stack) |
 | `uchiyomi-flaresolverr` | Cloudflare solver — **started automatically**; sources that need it use it with no config |
 | `uchiyomi-suwayomi` | the extension engine, so Mihon / Tachiyomi extensions work ([docs](extensions.md)) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,7 +70,7 @@ What you end up running:
 
 | Container | Role |
 |---|---|
-| `uchiyomi` | the app: the API and the PWA it serves |
+| `uchiyomi` | the app: the API, the PWA it serves, and the embedded Postgres database |
 | `uchiyomi-flaresolverr` | Cloudflare solver — **started automatically**; sources that need it use it with no config |
 | `uchiyomi-suwayomi` | the extension engine, so Mihon / Tachiyomi extensions work ([docs](extensions.md)) |
 


### PR DESCRIPTION
Removed mention of `uchiyomi-db` from the installation instructions.

Postgres runs inside the `uchiyomi` container by default and persists its data in the `uchiyomi_data` volume.

<!-- Thanks for contributing to Uchiyomi! Keep PRs focused: one topic per PR. -->

## Summary
Updates the installation docs to reflect the current embedded Postgres setup.

## Type
- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

## Testing
Verified against the current Docker Compose configuration

## Checklist
- [x] Focused scope (one topic)
- [x] Matches the existing TypeScript style
- [ ] Docs updated if user-facing (`docs/USAGE.md`)
- [x] No new default sources hardcoded to specific sites (the engine system reaches sites by URL)